### PR TITLE
(#9) Command line flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/llorllale/go-gitlint
 
 require (
+	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/google/uuid v1.1.0
 	github.com/stretchr/testify v1.2.2
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/src-d/go-git.v4 v4.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -48,6 +52,8 @@ golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9 h1:lkiLiLBHGoH3XnqSLUIaBsilG
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/src-d/go-billy.v4 v4.2.1 h1:omN5CrMrMcQ+4I8bJ0wEhOBPanIRWzFC953IiXKdYzo=

--- a/internal/issues/filters.go
+++ b/internal/issues/filters.go
@@ -19,12 +19,30 @@ import (
 	"regexp"
 
 	"github.com/llorllale/go-gitlint/internal/commits"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	subjectRegex = kingpin.Flag("subject-regex", "Filters commit subjects based on a regular expression.").String()    //nolint[gochecknoglobals]
+	bodyRegex    = kingpin.Flag("body-regex", "Filters commit message bodies based on a regular expression.").String() //nolint[gochecknoglobals]
 )
 
 // Filter identifies an issue with a commit.
 // A filter returning a zero-valued Issue signals that it found no issue
 // with the commit.
 type Filter func(*commits.Commit) Issue
+
+// Filters returns all filters configured by the user.
+func Filters() []Filter {
+	filters := make([]Filter, 0)
+	if subjectRegex != nil {
+		filters = append(filters, OfSubjectRegex(*subjectRegex))
+	}
+	if bodyRegex != nil {
+		filters = append(filters, OfBodyRegex(*bodyRegex))
+	}
+	return filters
+}
 
 // OfSubjectRegex tests a commit's subject with the regex.
 func OfSubjectRegex(regex string) Filter {

--- a/internal/issues/filters_test.go
+++ b/internal/issues/filters_test.go
@@ -21,6 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFilters(t *testing.T) {
+	sr := "abc123"
+	br := "bodyRegex"
+	subjectRegex = &sr
+	bodyRegex = &br
+	assert.Len(t, Filters(), 2)
+}
+
 func TestOfSubjectRegexMatch(t *testing.T) {
 	assert.Zero(t,
 		OfSubjectRegex(`\(#\d+\) [\w ]{10,50}`)(


### PR DESCRIPTION
This PR is for #9:
* Filters and repo path are specified via command
  line flags
* Can also specify flags via '.gitlint' file in
  $PWD (command line flags take precedence).
  The format of this file is the same as command
  line flags, where each is on a separate line.
* Left a puzzle to remove global variables later