### PR TITLE
(#27) Colored output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/llorllale/go-gitlint
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/fatih/color v1.7.0
 	github.com/google/uuid v1.1.0
+	github.com/mattn/go-colorable v0.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.6 // indirect
 	github.com/stretchr/testify v1.2.2
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/src-d/go-git.v4 v4.10.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.9.0 h1:rUF4PuzEjMChMiNsVjdI+SyLu7rEqpQ5reNFnhC7oFo=
 github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.1.1 h1:j3L6gSLQalDETeEg/Jg0mGY0/y/N6zI2xX1978P0Uqw=
@@ -28,6 +30,11 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
+github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.6 h1:SrwhHcpV4nWrMGdNcC2kXpMfcBVYGDuTArqyhocJgvA=
+github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=
@@ -50,6 +57,8 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9 h1:lkiLiLBHGoH3XnqSLUIaBsilGMUjI+Uy2Xu2JLUtTas=
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/internal/commits/commits.go
+++ b/internal/commits/commits.go
@@ -41,6 +41,11 @@ func (c *Commit) ID() string {
 	return c.Hash
 }
 
+// ShortID returns the commit hash's short form.
+func (c *Commit) ShortID() string {
+	return c.Hash[:7]
+}
+
 // Subject is the commit message's subject line.
 func (c *Commit) Subject() string {
 	return strings.Split(c.Message, "\n\n")[0]

--- a/internal/commits/commits_test.go
+++ b/internal/commits/commits_test.go
@@ -37,6 +37,14 @@ func TestCommitID(t *testing.T) {
 		"Commit.ID() must return the commit's hash")
 }
 
+func TestCommitShortID(t *testing.T) {
+	const ID = "c26cf8af130955c5c67cfea96f9532680b963628"
+	assert.Equal(t,
+		(&Commit{Hash: ID}).ShortID(),
+		ID[:7],
+		"Commit.ShortID() must equal the first 7 characters of the commit's hash")
+}
+
 func TestCommitSubject(t *testing.T) {
 	const subject = "test subject"
 	assert.Equal(t,

--- a/internal/issues/filters.go
+++ b/internal/issues/filters.go
@@ -90,7 +90,7 @@ func OfSubjectLength(length int) Filter {
 		var issue Issue
 		if len(c.Subject()) > length {
 			issue = Issue{
-				Desc:   fmt.Sprintf("subject is longer than %d", length),
+				Desc:   fmt.Sprintf("subject exceeds length [%d]", length),
 				Commit: *c,
 			}
 		}

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -15,9 +15,9 @@
 package issues
 
 import (
-	"fmt"
 	"io"
 
+	"github.com/fatih/color"
 	"github.com/llorllale/go-gitlint/internal/commits"
 )
 
@@ -25,10 +25,6 @@ import (
 type Issue struct {
 	Desc   string
 	Commit commits.Commit
-}
-
-func (i *Issue) String() string {
-	return fmt.Sprintf("Issue{Desc=%s Commit=%+v}", i.Desc, i.Commit)
 }
 
 // Issues is a collection of Issues.
@@ -42,7 +38,6 @@ func Collected(filters []Filter, cmts commits.Commits) Issues {
 			for _, f := range filters {
 				if issue := f(c); issue != (Issue{}) {
 					issues = append(issues, issue)
-					break
 				}
 			}
 		}
@@ -54,10 +49,13 @@ func Collected(filters []Filter, cmts commits.Commits) Issues {
 func Printed(w io.Writer, sep string, issues Issues) Issues {
 	return func() []Issue {
 		iss := issues()
-		for i := range iss {
-			_, err := w.Write(
-				[]byte(fmt.Sprintf("%s%s", iss[i].String(), sep)),
-			)
+		for idx := range iss {
+			i := iss[idx]
+			_, err := color.New(color.Bold).Fprintf(w, "%s: ", i.Commit.ShortID())
+			if err != nil {
+				panic(err)
+			}
+			_, err = color.New(color.FgRed).Fprintf(w, "%s%s", i.Desc, sep)
 			if err != nil {
 				panic(err)
 			}

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -15,6 +15,7 @@
 package issues
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/llorllale/go-gitlint/internal/commits"
@@ -60,21 +61,21 @@ func TestPrinted(t *testing.T) {
 		{
 			Desc: "issueA",
 			Commit: commits.Commit{
-				Hash:    "1",
+				Hash:    "18045269d8d2fd8f53d01883c6c7b548d0b9e3ae",
 				Message: "first commit",
 			},
 		},
 		{
 			Desc: "issueB",
 			Commit: commits.Commit{
-				Hash:    "2",
+				Hash:    "4be918ff8bfc91de77a1462707a8d2eb30956f93",
 				Message: "second commit",
 			},
 		},
 	}
 	var expected string
 	for _, i := range issues {
-		expected = expected + i.String() + sep
+		expected += fmt.Sprintf("%s: %s%s", i.Commit.ShortID(), i.Desc, sep)
 	}
 	writer := &mockWriter{}
 	Printed(
@@ -85,7 +86,7 @@ func TestPrinted(t *testing.T) {
 	)()
 	assert.Equal(t,
 		expected, writer.msg,
-		"issues.Printed() must concatenate Issue.String() with the separator")
+		"issues.Printed() must join Commit.ShortID() and the Issue.Desc with the separator")
 }
 
 type mockWriter struct {


### PR DESCRIPTION
PR for #27:
* Implemented colored output
* Also, `issues.Collected()` now collects all issues of a commit, not just the first one encountered.