### PR TITLE
(#34) Remove issues.Filter()

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ $ ./gitlint --help
 usage: gitlint [<flags>]
 
 Flags:
-  --help                         Show context-sensitive help (also try --help-long and --help-man).
-  --subject-regex=SUBJECT-REGEX  Filters commit subjects based on a regular expression.
-  --subject-len=SUBJECT-LEN      Filters commit subjects based on length.
-  --body-regex=BODY-REGEX        Filters commit message bodies based on a regular expression.
-  --path="."                     Path to the git repo ("." by default).
-  --since="1970-01-01"           A date in "yyyy-MM-dd" format starting from which commits will be analyzed (default: "1970-01-01")
+  --help                    Show context-sensitive help (also try --help-long and --help-man).
+  --path="."                Path to the git repo (default: ".").
+  --subject-regex=".*"      Commit subject line must conform to this regular expression (default: ".*").
+  --subject-len=4294967295  Commit subject line cannot exceed this length (default: math.MaxUint32).
+  --body-regex=".*"         Commit message body must conform to this regular expression (default: ".*").
+  --since="1970-01-01"      A date in "yyyy-MM-dd" format starting from which commits will be analyzed (default: "1970-01-01")
 ```
 Additionally, it will look for configurations in a file `.gitlint` in the current directory if it exists. This file's format is just the same command line flags but each on a separate line. *Flags passed through the command line take precedence.*
 

--- a/internal/issues/filters.go
+++ b/internal/issues/filters.go
@@ -19,38 +19,12 @@ import (
 	"regexp"
 
 	"github.com/llorllale/go-gitlint/internal/commits"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
-)
-
-var (
-	subjectRegex  = kingpin.Flag("subject-regex", "Filters commit subjects based on a regular expression.").String()    //nolint[gochecknoglobals]
-	subjectLength = kingpin.Flag("subject-len", "Filters commit subjects based on length.").Int()                       //nolint[gochecknoglobals]
-	bodyRegex     = kingpin.Flag("body-regex", "Filters commit message bodies based on a regular expression.").String() //nolint[gochecknoglobals]
 )
 
 // Filter identifies an issue with a commit.
 // A filter returning a zero-valued Issue signals that it found no issue
 // with the commit.
 type Filter func(*commits.Commit) Issue
-
-// Filters returns all filters configured by the user.
-// @todo #31 Function issues.Filters() can be removed by providing
-//  default values for each filter that will effectively render them
-//  disabled. For example, OfSubjectRegex() can be effectively disabled
-//  by using ".*" as regex.
-func Filters() []Filter {
-	filters := make([]Filter, 0)
-	if subjectRegex != nil {
-		filters = append(filters, OfSubjectRegex(*subjectRegex))
-	}
-	if bodyRegex != nil {
-		filters = append(filters, OfBodyRegex(*bodyRegex))
-	}
-	if subjectLength != nil && *subjectLength > 0 {
-		filters = append(filters, OfSubjectLength(*subjectLength))
-	}
-	return filters
-}
 
 // OfSubjectRegex tests a commit's subject with the regex.
 func OfSubjectRegex(regex string) Filter {

--- a/internal/issues/filters_test.go
+++ b/internal/issues/filters_test.go
@@ -21,16 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFilters(t *testing.T) {
-	sr := "abc123"
-	br := "bodyRegex"
-	sl := 5
-	subjectRegex = &sr
-	bodyRegex = &br
-	subjectLength = &sl
-	assert.Len(t, Filters(), 3)
-}
-
 func TestOfSubjectRegexMatch(t *testing.T) {
 	assert.Zero(t,
 		OfSubjectRegex(`\(#\d+\) [\w ]{10,50}`)(


### PR DESCRIPTION
PR for #34:
Removed `issues.Filter()` and placed all configuration variables inside `main` package.