### PR TITLE
(#38) Ability to ignore merge commits with --maxParents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Flags:
   --body-regex=".*"         Commit message body must conform to this regular expression (default: ".*").
   --since="1970-01-01"      A date in "yyyy-MM-dd" format starting from which commits will be analyzed (default: "1970-01-01").
   --msg-file=""             Only analyze the commit message found in this file (default: "").
+  --max-parents=1           Max number of parents a commit can have in order to be analyzed (default: 1). Useful for excluding merge commits.
 ```
 Additionally, it will look for configurations in a file `.gitlint` in the current directory if it exists. This file's format is just the same command line flags but each on a separate line. *Flags passed through the command line take precedence.*
 

--- a/cmd/go-gitlint/main.go
+++ b/cmd/go-gitlint/main.go
@@ -30,12 +30,13 @@ import (
 //  Figure out a way to remove these global variables. Whatever command line
 //  parser we choose should be able to auto-generate usage.
 var (
-	path          = kingpin.Flag("path", `Path to the git repo (default: ".").`).Default(".").String()                                                                          //nolint[gochecknoglobals]
-	subjectRegex  = kingpin.Flag("subject-regex", `Commit subject line must conform to this regular expression (default: ".*").`).Default(".*").String()                        //nolint[gochecknoglobals]
-	subjectLength = kingpin.Flag("subject-len", "Commit subject line cannot exceed this length (default: math.MaxInt32 - 1).").Default(strconv.Itoa(math.MaxInt32 - 1)).Int()   //nolint[gochecknoglobals]
-	bodyRegex     = kingpin.Flag("body-regex", `Commit message body must conform to this regular expression (default: ".*").`).Default(".*").String()                           //nolint[gochecknoglobals]
-	since         = kingpin.Flag("since", `A date in "yyyy-MM-dd" format starting from which commits will be analyzed (default: "1970-01-01").`).Default("1970-01-01").String() //nolint[gochecknoglobals]
-	msgFile       = kingpin.Flag("msg-file", `Only analyze the commit message found in this file (default: "").`).Default("").String()                                          //nolint[gochecknoglobals]
+	path          = kingpin.Flag("path", `Path to the git repo (default: ".").`).Default(".").String()                                                                                  //nolint[gochecknoglobals]
+	subjectRegex  = kingpin.Flag("subject-regex", `Commit subject line must conform to this regular expression (default: ".*").`).Default(".*").String()                                //nolint[gochecknoglobals]
+	subjectLength = kingpin.Flag("subject-len", "Commit subject line cannot exceed this length (default: math.MaxInt32 - 1).").Default(strconv.Itoa(math.MaxInt32 - 1)).Int()           //nolint[gochecknoglobals]
+	bodyRegex     = kingpin.Flag("body-regex", `Commit message body must conform to this regular expression (default: ".*").`).Default(".*").String()                                   //nolint[gochecknoglobals]
+	since         = kingpin.Flag("since", `A date in "yyyy-MM-dd" format starting from which commits will be analyzed (default: "1970-01-01").`).Default("1970-01-01").String()         //nolint[gochecknoglobals]
+	msgFile       = kingpin.Flag("msg-file", `Only analyze the commit message found in this file (default: "").`).Default("").String()                                                  //nolint[gochecknoglobals]
+	maxParents    = kingpin.Flag("max-parents", `Max number of parents a commit can have in order to be analyzed (default: 1). Useful for excluding merge commits.`).Default("1").Int() //nolint[gochecknoglobals]
 )
 
 func main() {
@@ -60,10 +61,13 @@ func main() {
 							return commits.MsgIn(file)
 						},
 						func() commits.Commits {
-							return commits.Since(
-								*since,
-								commits.In(
-									repo.Filesystem(*path),
+							return commits.WithMaxParents(
+								*maxParents,
+								commits.Since(
+									*since,
+									commits.In(
+										repo.Filesystem(*path),
+									),
 								),
 							)
 						},

--- a/internal/commits/commits_test.go
+++ b/internal/commits/commits_test.go
@@ -51,7 +51,7 @@ func TestCommitSubject(t *testing.T) {
 	assert.Equal(t,
 		(&Commit{Message: subject + "\n\ntest body"}).Subject(),
 		subject,
-		`Commit.Subject() must return the substring before the first \n\n`)
+		`Commit.Subject() must return the substring before the first \n`)
 }
 
 func TestCommitBody(t *testing.T) {
@@ -104,6 +104,19 @@ func TestMsgIn(t *testing.T) {
 	assert.Len(t, commits, 1)
 	assert.Equal(t, "test subject", commits[0].Subject())
 	assert.Equal(t, "test body", commits[0].Body())
+}
+
+func TestWithMaxParents(t *testing.T) {
+	const max = 1
+	commits := WithMaxParents(max, func() []*Commit {
+		return []*Commit{
+			{NumParents: max},
+			{NumParents: 2},
+			{NumParents: 3},
+		}
+	})()
+	assert.Len(t, commits, 1)
+	assert.Equal(t, commits[0].NumParents, max)
 }
 
 // A git repo initialized and with one commit per each of the messages provided.


### PR DESCRIPTION
PR for #38:
* Adds `--max-parents` flag (default value of `1`), useful for ignoring merge commits