### PR TITLE
(#52) Ignore authors by name and email

### DIFF
--- a/.dependency_license
+++ b/.dependency_license
@@ -12,4 +12,5 @@ go\.sum, Ignore
 \.pdd, Ignore
 \.travis\.yml, Ignore
 \.idea, Ignore
+\.vscode, Ignore
 download-gitlint.sh, Ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 
 " goreleaser
 dist/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Flags:
   --since="1970-01-01"         A date in "yyyy-MM-dd" format starting from which commits will be analyzed (default: "1970-01-01").
   --msg-file=""                Only analyze the commit message found in this file (default: "").
   --max-parents=1              Max number of parents a commit can have in order to be analyzed (default: 1). Useful for excluding merge commits.
+  --excl-author-names="$a"     Don't lint commits with authors whose names match these comma-separated regular expressions (default: '$a').
+  --excl-author-emails="$a"    Don't lint commits with authors whose emails match these comma-separated regular expressions (default: '$a').
 ```
 Additionally, it will look for configurations in a file `.gitlint` in the current directory if it exists. This file's format is just the same command line flags but each on a separate line. *Flags passed through the command line take precedence.*
 

--- a/internal/commits/commits_test.go
+++ b/internal/commits/commits_test.go
@@ -119,6 +119,36 @@ func TestWithMaxParents(t *testing.T) {
 	assert.Equal(t, commits[0].NumParents, max)
 }
 
+func TestNotAuthoredByNames(t *testing.T) { //nolint:dupl
+	filtered := &Commit{Author: &Author{Name: uuid.New().String()}}
+	expected := []*Commit{
+		{Author: &Author{Name: uuid.New().String()}},
+		{Author: &Author{Name: uuid.New().String()}},
+		{Author: &Author{Name: uuid.New().String()}},
+		{Author: &Author{Name: uuid.New().String()}},
+	}
+	actual := NotAuthoredByNames(
+		[]string{filtered.Author.Name},
+		func() []*Commit { return append(expected, filtered) },
+	)()
+	assert.Equal(t, expected, actual)
+}
+
+func TestNotAuthoredByEmails(t *testing.T) { //nolint:dupl
+	filtered := &Commit{Author: &Author{Email: uuid.New().String()}}
+	expected := []*Commit{
+		{Author: &Author{Email: uuid.New().String()}},
+		{Author: &Author{Email: uuid.New().String()}},
+		{Author: &Author{Email: uuid.New().String()}},
+		{Author: &Author{Email: uuid.New().String()}},
+	}
+	actual := NotAuthoredByEmails(
+		[]string{filtered.Author.Email},
+		func() []*Commit { return append(expected, filtered) },
+	)()
+	assert.Equal(t, expected, actual)
+}
+
 // A git repo initialized and with one commit per each of the messages provided.
 // This repo is created in a temporary directory; use the cleanup function
 // to delete it afterwards.


### PR DESCRIPTION
For #52 

Two new flags:
* `excl-author-names`: comma-separated list of regexes matched against names of authors. 
* `excl-author-emails`: comma-separated list of regexes matched against emails of authors

If an authors name or email matches these then the commit will be excluded from the analysis.